### PR TITLE
Add support to choose default package size and delivery instructions on marktplaats 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,17 @@ Install the required Python packages:
 pip install -r requirements.txt
 ```
 
+# Installing instructions for  Mac M1
 
+To make the installation work on osx apple silicon, you need to install some additional dependencies. 
 
+```shell
+pyenv install 3.7.13
+python -m pip install PyQt5
+brew install pygobject3 libffi
+pip install -Iv undetected-chromedriver==3.0.3
+pip install -r requirements.txt
+```
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-undetected-chromedriver
+undetected-chromedriver==3.5.5
 selenium
 natsort
 pygobject # needed for pywebview


### PR DESCRIPTION
    The marktplaats site has changed a bit so fixes for:
        - choosing a default delivery method
        - choosing a default package size
    Some changess to make the script more easy to use:
        - Better installation instructions for mac.
        - Ability to change timeouts and other delays
        - Ability to upload only to one site